### PR TITLE
Actor translation

### DIFF
--- a/core/src/com/mygdx/threedtests/LightsCameraActionInputController.java
+++ b/core/src/com/mygdx/threedtests/LightsCameraActionInputController.java
@@ -8,12 +8,9 @@ import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.graphics.g3d.attributes.DirectionalLightsAttribute;
 import com.badlogic.gdx.graphics.g3d.environment.DirectionalShadowLight;
 import com.badlogic.gdx.graphics.g3d.utils.CameraInputController;
-import com.badlogic.gdx.math.Matrix3;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Quaternion;
 import com.badlogic.gdx.math.Vector3;
-
-import static com.badlogic.gdx.math.MathUtils.*;
 
 public class LightsCameraActionInputController extends CameraInputController {
 
@@ -104,7 +101,7 @@ public class LightsCameraActionInputController extends CameraInputController {
     public void update() {
         final float delta = Gdx.graphics.getDeltaTime();
 
-
+        // Repetitive on purpose so that each key-press maintains its own logic handling.
         if (rotateRightPressed) {
             if (touched == 0) {
                 rotateCamera(-delta, 0);
@@ -144,6 +141,8 @@ public class LightsCameraActionInputController extends CameraInputController {
 
     @Override
     public boolean touchDown(int screenX, int screenY, int pointer, int button) {
+        Gdx.input.setCursorCatched(true);
+
         touched += 1;
         multiTouch = touched > 1;
         if (multiTouch) {
@@ -168,6 +167,8 @@ public class LightsCameraActionInputController extends CameraInputController {
         multiTouch = touched > 1;
         if (touched > 0) {
             this.button = button == snapToActorButton ? rotateButton : snapToActorButton;
+        } else {
+            Gdx.input.setCursorCatched(false);
         }
         return super.touchUp(screenX, screenY, pointer, button);
     }

--- a/core/src/com/mygdx/threedtests/LightsCameraActionInputController.java
+++ b/core/src/com/mygdx/threedtests/LightsCameraActionInputController.java
@@ -8,7 +8,6 @@ import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.graphics.g3d.attributes.DirectionalLightsAttribute;
 import com.badlogic.gdx.graphics.g3d.environment.DirectionalShadowLight;
 import com.badlogic.gdx.graphics.g3d.utils.CameraInputController;
-import com.badlogic.gdx.math.Quaternion;
 import com.badlogic.gdx.math.Vector3;
 
 public class LightsCameraActionInputController extends CameraInputController {
@@ -17,7 +16,10 @@ public class LightsCameraActionInputController extends CameraInputController {
     protected Environment environment;
     protected ModelInstance actor;
 
+    // Mouse
+    public int snapToActorButton = Input.Buttons.RIGHT;
 
+    // Keyboard
     protected boolean controlPressed;
     public int controlKey = Input.Keys.CONTROL_LEFT;
     protected boolean changeLightXPressed;
@@ -29,9 +31,9 @@ public class LightsCameraActionInputController extends CameraInputController {
     public int toggleDirectionLightKey = Input.Keys.NUMPAD_0;
     protected boolean lightOn = true;
 
+    // Drag support
     private float startX, startY, endX;
     private final Vector3 tmpV1 = new Vector3();
-    private final Quaternion cameraRotation = new Quaternion();
 
     public LightsCameraActionInputController(Camera cam, DirectionalShadowLight light, Environment environment, ModelInstance actor) {
         super(cam);
@@ -106,14 +108,14 @@ public class LightsCameraActionInputController extends CameraInputController {
         touched += 1;
         multiTouch = touched > 1;
         if (multiTouch) {
-            this.button = translateButton;
+            this.button = snapToActorButton;
             button = this.button;
         }
         startX = screenX;
         startY = screenY;
 
         // Snap actor to current camera vector
-        if (button == translateButton) {
+        if (button == snapToActorButton) {
             rotateActor(endX);
             endX = 0f;
         }
@@ -125,7 +127,7 @@ public class LightsCameraActionInputController extends CameraInputController {
         touched -= 1;
         multiTouch = touched > 1;
         Gdx.app.log("touch-up event", "down: " + pointer + " " + button + this.button + " \ttouched: " + touched + " " + multiTouch);
-        if (touched > 0 && button == translateButton) {
+        if (touched > 0 && button == snapToActorButton) {
             this.button = rotateButton;
         }
         return super.touchUp(screenX, screenY, pointer, button) || activatePressed;
@@ -147,7 +149,7 @@ public class LightsCameraActionInputController extends CameraInputController {
             rotateCamera(deltaX, deltaY);
         }
         // Rotate actor with camera
-        else if (button == translateButton) { // TODO: rename translate to snap
+        else if (button == snapToActorButton) {
             rotateCamera(deltaX, deltaY);
             rotateActor(deltaX);
         }

--- a/core/src/com/mygdx/threedtests/LightsCameraActionInputController.java
+++ b/core/src/com/mygdx/threedtests/LightsCameraActionInputController.java
@@ -127,7 +127,7 @@ public class LightsCameraActionInputController extends CameraInputController {
                 rotateActor(delta);
             }
         }
-        if (forwardPressed) {
+        if (forwardPressed || touched == 2) {
             moveActor(delta, forwardVector);
             moveCamera(tmpV1);
         }
@@ -166,6 +166,7 @@ public class LightsCameraActionInputController extends CameraInputController {
         touched -= 1;
         multiTouch = touched > 1;
         if (touched > 0) {
+            // Button is the just-release button. this.button is the button still being pressed.
             this.button = button == snapToActorButton ? rotateButton : snapToActorButton;
         } else {
             Gdx.input.setCursorCatched(false);

--- a/core/src/com/mygdx/threedtests/ThreeDTest.java
+++ b/core/src/com/mygdx/threedtests/ThreeDTest.java
@@ -37,7 +37,7 @@ public class ThreeDTest extends ApplicationAdapter {
 
 		// Create Camera
 		cam = new PerspectiveCamera(67, width, height);
-		cam.position.set(8.4f, 4f, 1.1f);
+		cam.position.set(8.4f, 5f, 1.1f);
 		cam.lookAt(2.8f, 0f, -0.8f);
 		cam.near = 1f;
 		cam.far = 50f;


### PR DESCRIPTION
Adds traditional mouse + keyboard movement for the main focus actor.

WASD keys move the actor forward, backwards, and rotates.
Left-click moves the camera around the actor independently from actor movement.
Right-click snaps the actor's facing direction to the camera {x,z} direction, forces strafe-movement  from rotation keys, and controls actor turning.
Holding both mouse buttons moves the actor forward and follows right-click camera rules.
Scroll wheel zooms camera in and out (currently no limit to how far in either direction).

TODO:
Prevent camera from rotating upside-down.
Fix stuttering when spamming mouse clicks.
Set a max zoom level (in and out).